### PR TITLE
0.6.4 — Multiverse-Core V5 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.zerotoil</groupId>
     <artifactId>CyberWorldReset</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <packaging>jar</packaging>
 
     <name>CyberWorldReset</name>
@@ -90,6 +90,10 @@
             <id>sk89q-repo</id>
             <url>https://maven.enginehub.org/repo/</url>
         </repository>
+        <repository>
+            <id>onarandombox</id>
+            <url>https://repo.onarandombox.com/content/groups/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -113,6 +117,12 @@
             <groupId>com.onarandombox.multiversecore</groupId>
             <artifactId>Multiverse-Core</artifactId>
             <version>4.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mvplugins.multiverse.core</groupId>
+            <artifactId>multiverse-core</artifactId>
+            <version>5.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/net/zerotoil/cyberworldreset/objects/WorldObject.java
+++ b/src/main/java/net/zerotoil/cyberworldreset/objects/WorldObject.java
@@ -1,8 +1,6 @@
 package net.zerotoil.cyberworldreset.objects;
 
 import com.Zrips.CMI.CMI;
-import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MultiversePlugin;
 import com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals;
 import com.onarandombox.MultiversePortals.MultiversePortals;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -15,9 +13,11 @@ import org.bukkit.*;
 import org.bukkit.boss.DragonBattle;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.*;
+import java.lang.reflect.Method;
 import java.util.*;
 
 public class WorldObject {
@@ -202,7 +202,8 @@ public class WorldObject {
 
         if (main.isMultiverseEnabled()) {
             try {
-                main.multiverse().getMVWorldManager().getMVWorld(getWorld()).setKeepSpawnInMemory(main.config().getLoadingType().matches("(?i)STANDARD"));
+                Object mvWorld = main.getMVWorld(getWorld());
+                main.setMvWorldKeepSpawnInMemory(mvWorld, main.config().getLoadingType().matches("(?i)STANDARD"));
             } catch (Exception e) {
                 main.logger("&cFailed to prevent Multiverse from loading spawn chunks. Please check your generator name.");
             }
@@ -430,7 +431,7 @@ public class WorldObject {
 
         try {
             if (main.isMultiverseEnabled())
-                main.multiverse().getMVWorldManager().getMVWorld(getWorld()).setSpawnLocation(getWorld().getSpawnLocation());
+                main.setMvSpawnLocation(main.getMVWorld(getWorld()), getWorld().getSpawnLocation());
         } catch (Exception e) {
             main.logger("&cFailed to set spawn location for " + worldName + " in Multiverse.");
         }
@@ -471,11 +472,21 @@ public class WorldObject {
         // refresh MV portals
         if (main.config().isMvPortalRefresh()) {
 
-            MultiversePortals portals = (MultiversePortals) Bukkit.getServer().getPluginManager().getPlugin("Multiverse-Portals");
-            if (portals != null) portals.reloadConfigs();
+            Plugin portals = Bukkit.getServer().getPluginManager().getPlugin("Multiverse-Portals");
+            if (portals != null) {
+                try {
+                    Method m = portals.getClass().getMethod("reloadConfigs");
+                    m.invoke(portals);
+                } catch (Exception ignored) {}
+            }
 
-            MultiverseNetherPortals netherportals = (MultiverseNetherPortals) Bukkit.getServer().getPluginManager().getPlugin("Multiverse-NetherPortals");
-            if (netherportals != null) netherportals.loadConfig();
+            Plugin netherportals = Bukkit.getServer().getPluginManager().getPlugin("Multiverse-NetherPortals");
+            if (netherportals != null) {
+                try {
+                    Method m = netherportals.getClass().getMethod("loadConfig");
+                    m.invoke(netherportals);
+                } catch (Exception ignored) {}
+            }
 
         }
 


### PR DESCRIPTION
This pull request updates the project to support both Multiverse-Core v4 and the new v5 (org.mvplugins.multiverse.core) without requiring a compile-time dependency on either. This is achieved by using reflection for all Multiverse interactions, improving compatibility and future-proofing the plugin. The changes also update the project version and add the necessary Maven repository and dependency for Multiverse-Core v5.

### Multiverse compatibility and reflection (most important):

* All direct references to Multiverse-Core classes have been removed in favor of reflection-based access, allowing runtime compatibility with both v4 and v5 versions. Helper methods (`getMVWorldManager`, `getMVWorld`, etc.) are provided in `CyberWorldReset.java` for safe interaction

### Dependency and repository updates:

* The Maven `pom.xml` adds the Multiverse-Core v5 repository and dependency, and bumps the project version to 0.6.4.

### Plugin interaction improvements:

* All interactions with Multiverse-Portals and Multiverse-NetherPortals plugins now use reflection, removing compile-time dependencies and improving robustness.